### PR TITLE
profile-step-page 무한 랜더링 해결 및 홈 페이지 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@headlessui/react": "^2.2.4",
         "@stomp/stompjs": "^7.1.1",
         "@tanstack/react-query": "^5.81.5",
-        "@tanstack/react-query-devtools": "^5.83.0",
+        "@tanstack/react-query-devtools": "^5.83.1",
         "axios": "^1.10.0",
         "clsx": "^2.1.1",
         "firebase": "^12.0.0",
@@ -3111,9 +3111,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
-      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
+      "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3121,9 +3121,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.81.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
-      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.83.1.tgz",
+      "integrity": "sha512-KOQ3SMLnHHrnwwAHflK50QT8zEHg3rjPZx6cd+G7yZl4vU9moctTQU1A3zvHYEXabzKu5G31bcll6qhNCya9+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3131,12 +3131,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
-      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.1.tgz",
+      "integrity": "sha512-JHZ3xox3p0sqCgM7ykBRtMWSLmWgjR7I+oJMAZ1beK/O/gfShI2b/PdovL2/ivVLUZklXgBenQu4ZjPhIM+yrw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.83.0"
+        "@tanstack/query-core": "5.83.1"
       },
       "funding": {
         "type": "github",
@@ -3147,19 +3147,19 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.83.0.tgz",
-      "integrity": "sha512-yfp8Uqd3I1jgx8gl0lxbSSESu5y4MO2ThOPBnGNTYs0P+ZFu+E9g5IdOngyUGuo6Uz6Qa7p9TLdZEX3ntik2fQ==",
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.83.1.tgz",
+      "integrity": "sha512-t5zcIHoSbT4ducv5YBYULgol6mt1gflHBLbN9oMa/VvPxVtQBY7nyDWFzOYycGXLlH3RrSp7w+oFBTB2GS04Ug==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.81.2"
+        "@tanstack/query-devtools": "5.83.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-query": "^5.83.1",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@headlessui/react": "^2.2.4",
     "@stomp/stompjs": "^7.1.1",
     "@tanstack/react-query": "^5.81.5",
-    "@tanstack/react-query-devtools": "^5.83.0",
+    "@tanstack/react-query-devtools": "^5.83.1",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
     "firebase": "^12.0.0",

--- a/src/pages/login-page/profile-step-page.tsx
+++ b/src/pages/login-page/profile-step-page.tsx
@@ -10,7 +10,7 @@ import Step2 from '@/assets/icons/step2.svg';
 import Step3 from '@/assets/icons/step3.svg';
 import Step4 from '@/assets/icons/step4.svg';
 import Step5 from '@/assets/icons/step5.svg';
-import type { TimeTable as TimeTableType} from '../../types/user';
+import type { TimeTable as TimeTableType } from '../../types/user';
 import { getColleges, getDepartments, patchSignUp } from '../../api/login-page/login';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,22 +19,26 @@ export default function ProfileStepPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [name, setName] = useState('');
   const [studentNo, setStudentNo] = useState('');
-  const [college, setCollege] = useState<{id:number; name:string}[]>();
+  const [college, setCollege] = useState<{ id: number; name: string }[]>();
   const [collegeId, setCollegeId] = useState(0);
-  const [department, setDepartment] = useState<{id:number; name:string}[]>();
+  const [department, setDepartment] = useState<{ id: number; name: string }[]>();
   const [departmentId, setDepartmentId] = useState(0);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [timeTables, setTimeTables] = useState<TimeTableType[]>([]);
   const navigate = useNavigate();
 
-  setTimeTables([
-    {
-      dayOfWeek: "MON",
-      startTime: "09:00",
-      endTime: "10:00",
-      subjectName: ""
-    }
-  ])
+  // 여기 수정함-> 무한 렌더 방지를 위해 useEffect로 이동
+  useEffect(() => {
+    setTimeTables([
+      {
+        dayOfWeek: "MON",
+        startTime: "09:00",
+        endTime: "10:00",
+        subjectName: ""
+      }
+    ]);
+  }, []);
+
   const StepImages =
     step === 0
       ? Step1
@@ -47,7 +51,7 @@ export default function ProfileStepPage() {
       : step === 4
       ? Step5
       : undefined;
-  
+
   const modalText =
     '런치챗은 교내 자기계발을 위한\n관심사 기반 밥약/커피챗 플랫폼입니다.\n건강한 소통 문화를 위해\n실명제로 운영됩니다.';
 
@@ -56,51 +60,51 @@ export default function ProfileStepPage() {
   };
 
   {/*단과대 불러오기*/}
-  useEffect(()=>{
+  useEffect(() => {
     (async () => {
       try {
         const data = await getColleges();
         setCollege(data.result);
-      }catch(error){
+      } catch (error) {
         console.log('실패');
       }
     })();
-  },[]);
+  }, []);
 
   {/*학과 불러오기*/}
-  useEffect(()=>{
+  useEffect(() => {
     (async () => {
       try {
         const data = await getDepartments(collegeId);
         setDepartment(data.result);
-      }catch(error){
+      } catch (error) {
         console.log('실패');
       }
     })();
-  },[collegeId]);
+  }, [collegeId]);
 
   {/*회원가입 정보 패치*/}
   useEffect(() => {
     if (step === 5) {
       const body = {
-        membername: name, 
-        studentNo: studentNo, 
-        collegeId: collegeId, 
-        departmentId: departmentId, 
-        interests: selectedTags, 
+        membername: name,
+        studentNo: studentNo,
+        collegeId: collegeId,
+        departmentId: departmentId,
+        interests: selectedTags,
         timeTables: timeTables
       };
       console.log(body);
       (async () => {
-        try{
+        try {
           await patchSignUp(body);
           navigate(`/onboarding/complete`);
-        }catch(error) {
+        } catch (error) {
           console.log('실패');
         }
       })();
     }
-  },[step]);
+  }, [step]);
 
   return (
     <div>
@@ -170,7 +174,6 @@ export default function ProfileStepPage() {
                     </div>
                   </ListboxButton>
 
-                  {/* 옵션 */}
                   <ListboxOptions className="absolute right-0 w-[127px] px-[11px] py-[10px] border border-[#D4D4D4] mt-1 flex flex-col gap-3">
                     {college?.map((college) => (
                       <ListboxOption
@@ -197,7 +200,6 @@ export default function ProfileStepPage() {
                     </div>
                   </ListboxButton>
 
-                  {/* 옵션 */}
                   <ListboxOptions className="absolute right-0 w-[127px] px-[11px] py-[10px] border border-[#D4D4D4] mt-1 flex flex-col gap-3">
                     {department?.map((value) => (
                       <ListboxOption
@@ -224,7 +226,7 @@ export default function ProfileStepPage() {
               최대 3개까지 선택 가능합니다.
             </p>
             <div className="w-full">
-              <TagSelectList selected={selectedTags} onChange={setSelectedTags}/>
+              <TagSelectList selected={selectedTags} onChange={setSelectedTags} />
             </div>
           </div>
         )}

--- a/src/pages/login-page/redirect-page.tsx
+++ b/src/pages/login-page/redirect-page.tsx
@@ -17,7 +17,7 @@ export default function GoogleLoginPage() {
 
       try {
         const res = await getLogin(code);
-        
+        console.log(" 로그인 응답:", res.data);  //콘솔 로그 확인하려고 추가함
         setTimeout(() => {
           if (res.data.result === "isNewUser") navigate(`/onboarding/profile`);
           else navigate(`/onboarding/complete`);

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,38 @@
+// src/types/filters.ts
+
+/** userKeywords 항목 */
+export interface MemberKeywordDto {
+  id: number
+  type: string
+  title: string
+  description: string
+}
+
+/** /api/members/filters 결과 단위 */
+export interface MemberFilterDto {
+  memberId: number
+  memberName: string
+  profileImageUrl: string
+  studentNo: string
+  department: string
+  userInterests: string[]
+  userKeywords: MemberKeywordDto[]
+}
+
+/** /api/members/filters 전체 응답 */
+export interface ResponseMembersFiltersDto {
+  isSuccess: boolean
+  code: string
+  message: string
+  result: {
+    data: MemberFilterDto[]
+    meta: {
+      currentPage: number
+      pageSize: number
+      totalItems: number
+      totalPages: number
+      hasNext: boolean
+    }
+  }
+}
+

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -32,3 +32,23 @@ export interface ResponseRecommendationDto {
   message: string;
   result: RecommendationProfile[];
 }
+
+
+/** 인기 멤버 단일 프로필 */
+export interface PopularProfile {
+  memberId: number;
+  memberName: string;
+  profileImageUrl: string;
+  studentNo: string;
+  department: string;
+  userInterests: string[];
+  // userKeywords가 필요없으면 빼셔도 됩니다.
+}
+
+/** 인기 멤버 전체 응답 */
+export interface ResponsePopularDto {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: PopularProfile[];
+}


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 상세
- 원인: `/onboarding/profile` 페이지에서 `setTimeTables(...)`가 컴포넌트 바디에서 직접 호출되어 무한 렌더 발생
- 조치: 해당 부분을 `useEffect` 안으로 옮겨서 해결 완료
- 해결 이휴 ->  홈페이지 '관신사' , '이런 사람 어때요" api 연동 완료
- 둘러보기 무한 스크롤 에러 있어 다시 작업 중





