### PR TITLE
 ExplorePage의 selectedCategory 초기값을 URL 쿼리에서 바로 세팅하도록 수정

### DIFF
--- a/src/pages/Explore-Page/explore-page.tsx
+++ b/src/pages/Explore-Page/explore-page.tsx
@@ -52,7 +52,10 @@ export default function ExplorePage() {
   const [searchParams] = useSearchParams();
   const { setHideNav } = useNav();
 
-  const [selectedCategory, setSelectedCategory] = useState('전체');
+  //초기값을 URL 쿼리에서 즉시 가져오도록 수정
+  const initialCategory = searchParams.get('category') ?? '전체';
+  const [selectedCategory, setSelectedCategory] = useState(initialCategory);
+
   const [showDeptModal, setShowDeptModal] = useState(false);
   const [showYearModal, setShowYearModal] = useState(false);
 
@@ -72,11 +75,13 @@ export default function ExplorePage() {
 
   const { ref, inView } = useInView({ threshold: 0 });
 
-  // 쿼리 파라미터로 선택 카테고리 초기화
+  // 쿼리 변화 시에만 상태 동기화 초기 렌더 레이스 방지함
   useEffect(() => {
-    const param = searchParams.get('category');
-    setSelectedCategory(param ?? '전체');
-  }, [searchParams]);
+    const param = searchParams.get('category') ?? '전체';
+    if (param !== selectedCategory) {
+      setSelectedCategory(param);
+    }
+  }, [searchParams, selectedCategory]);
 
   // 단대 목록
   useEffect(() => {
@@ -158,7 +163,7 @@ export default function ExplorePage() {
     setProfiles([]);
     loadPage(0, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [buildParams]); 
+  }, [buildParams]);
 
   // 감지되면 다음 페이지 로드
   useEffect(() => {
@@ -192,6 +197,7 @@ export default function ExplorePage() {
     <div className="w-full min-h-screen bg-white font-[pretendard] flex flex-col items-center pb-28">
       <div className="w-full max-w-[700px]">
         <CategorySlider
+          key={selectedCategory} 
           categories={categories}
           selectedCategory={selectedCategory}
           onSelect={setSelectedCategory}

--- a/src/pages/chatting-page/chatting-room.tsx
+++ b/src/pages/chatting-page/chatting-room.tsx
@@ -167,7 +167,10 @@ export default function ChattingRoom() {
         </div>
       )}
 
-      <div className="fixed left-0 right-0" style={{ bottom: `${keyboardOffset}px` }}>
+      <div
+        className="fixed left-0 right-0 max-w-[480px] w-full mx-auto"
+        style={{ bottom: `${keyboardOffset}px` }}
+      >
         <ChatInput value={message} onChange={setMessage} onSubmit={handleSendMessage} />
       </div>
     </div>


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
ExplorePage가 마운트 시 기본값(‘전체’)으로 먼저 API를 호출한 뒤, URL 쿼리(category)를 반영하면서 다시 API 요청을 보내는 레이스 발생
ExplorePage의 selectedCategory 초기값을 URL 쿼리에서 바로 세팅하도록 수정
쿼리 변경 시에만 selectedCategory를 동기화하도록 useEffect 조정